### PR TITLE
Completed Anaglyph filter (removal of dubois string on Android) and Resolved bug where Anaglyph or Interlaced modes would not be honored when relaunching title.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: windows-latest
         strategy:
           matrix:
-            target: ["msvc"]
+            target: ["msvc", "msys2"]
         defaults:
           run:
             shell: ${{ (matrix.target == 'msys2' && 'msys2') || 'bash' }} {0}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ jobs:
         runs-on: windows-latest
         strategy:
           matrix:
-            target: ["msvc"]
+            target: ["msvc", "msys2"]
         defaults:
           run:
             shell: ${{ (matrix.target == 'msys2' && 'msys2') || 'bash' }} {0}

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -83,7 +83,7 @@
     <string name="permission_denied">Permission denied</string>
     <string name="add_games_warning">Skip selecting games folder?</string>
     <string name="add_games_warning_description">Games won\'t be displayed in the Games list if a folder isn\'t selected.</string>
-    <string name="add_games_warning_help">https://Lemonade-emu.org/wiki/dumping-game-cartridges/</string>
+    <string name="add_games_warning_help">https://lemonade-emu.github.io/pages/dumping-game-cartridges/</string>
     <string name="warning_help">Help</string>
     <string name="warning_skip">Skip</string>
     <string name="warning_cancel">Cancel</string>
@@ -279,7 +279,7 @@
     <string name="learn_more">Learn More</string>
     <string name="close">Close</string>
     <string name="reset_to_default">Reset to Default</string>
-    <string name="redump_games"><![CDATA[Please follow the guides to redump your <a href="https://Lemonade-emu.org/wiki/dumping-game-cartridges/">game cartidges</a> or <a href="https://Lemonade-emu.org/wiki/dumping-installed-titles/">installed titles</a>.]]></string>
+    <string name="redump_games"><![CDATA[Please follow the guides to redump your <a href="https://lemonade-emu.github.io/pages/dumping-game-cartridges/">game cartidges</a> or <a href="https://lemonade-emu.github.io/pages/dumping-installed-titles/">installed titles</a>.]]></string>
     <string name="option_default">Default</string>
     <string name="none">None</string>
     <string name="auto">Auto</string>

--- a/src/audio_core/openal_sink.cpp
+++ b/src/audio_core/openal_sink.cpp
@@ -73,8 +73,9 @@ OpenALSink::OpenALSink(std::string device_name) : impl(std::make_unique<Impl>())
 
     auto alBufferCallbackSOFT =
         reinterpret_cast<LPALBUFFERCALLBACKSOFT>(alGetProcAddress("alBufferCallbackSOFT"));
-    alBufferCallbackSOFT(impl->buffer, AL_FORMAT_STEREO16, native_sample_rate, &Impl::Callback,
-                         impl.get());
+    alBufferCallbackSOFT(impl->buffer, AL_FORMAT_STEREO16, native_sample_rate,
+                         reinterpret_cast<ALBUFFERCALLBACKTYPESOFT>(&Impl::Callback), impl.get());
+
     if (alGetError() != AL_NO_ERROR) {
         LOG_CRITICAL(Audio_Sink, "alBufferCallbackSOFT failed: {}", alGetError());
         Close();

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -511,7 +511,7 @@ struct Values {
 
     SwitchableSetting<bool> filter_mode{true, "filter_mode"};
     SwitchableSetting<std::string> pp_shader_name{"none (builtin)", "pp_shader_name"};
-    SwitchableSetting<std::string> anaglyph_shader_name{"dubois (builtin)", "anaglyph_shader_name"};
+    SwitchableSetting<std::string> anaglyph_shader_name{"rendepth (builtin)", "anaglyph_shader_name"};
 
     SwitchableSetting<bool> dump_textures{false, "dump_textures"};
     SwitchableSetting<bool> custom_textures{false, "custom_textures"};

--- a/src/core/hle/service/soc/soc_u.cpp
+++ b/src/core/hle/service/soc/soc_u.cpp
@@ -20,6 +20,9 @@
 #include "core/hle/result.h"
 #include "core/hle/service/soc/soc_u.h"
 
+// Suppress deprecated msvc warnings for now
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
+
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -2251,7 +2254,7 @@ std::optional<SOC_U::InterfaceInfo> SOC_U::GetDefaultInterfaceInfo() {
     socklen_t s_info_len = sizeof(struct sockaddr_in);
     sockaddr_in s_info;
 
-    if ((sock_fd = ::socket(AF_INET, SOCK_STREAM, 0)) == -1) {
+    if (static_cast<int>(sock_fd = ::socket(AF_INET, SOCK_STREAM, 0)) == -1) {
         return std::nullopt;
     }
 
@@ -2269,7 +2272,7 @@ std::optional<SOC_U::InterfaceInfo> SOC_U::GetDefaultInterfaceInfo() {
 
 #ifdef _WIN32
     sock_fd = WSASocket(AF_INET, SOCK_DGRAM, 0, 0, 0, 0);
-    if (sock_fd == SOCKET_ERROR) {
+    if (static_cast<int>(sock_fd) == SOCKET_ERROR) {
         return std::nullopt;
     }
 

--- a/src/lemonade_qt/CMakeLists.txt
+++ b/src/lemonade_qt/CMakeLists.txt
@@ -285,6 +285,7 @@ elseif(WIN32)
     # compile as a win32 gui application instead of a console application
     target_link_libraries(lemonade-qt PRIVATE Qt6::EntryPointImplementation)
     set_target_properties(lemonade-qt PROPERTIES OUTPUT_NAME "lemonade-qt")
+    target_link_libraries(lemonade-qt PRIVATE dwmapi)
     if(MSVC)
         set_target_properties(lemonade-qt PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS")
     elseif(MINGW)

--- a/src/lemonade_qt/configuration/configure_enhancements.cpp
+++ b/src/lemonade_qt/configuration/configure_enhancements.cpp
@@ -110,7 +110,7 @@ void ConfigureEnhancements::updateShaders(Settings::StereoRenderOption stereo_op
 
     std::string current_shader;
     if (stereo_option == Settings::StereoRenderOption::Anaglyph) {
-        ui->shader_combobox->addItem(QStringLiteral("dubois (builtin)"));
+        ui->shader_combobox->addItem(QStringLiteral("rendepth (builtin)"));
         current_shader = Settings::values.anaglyph_shader_name.GetValue();
     } else {
         ui->shader_combobox->addItem(QStringLiteral("none (builtin)"));

--- a/src/lemonade_qt/main.cpp
+++ b/src/lemonade_qt/main.cpp
@@ -971,9 +971,6 @@ void GMainWindow::ConnectMenuEvents() {
 
     // Help
     connect_menu(ui->action_Open_Citra_Folder, &GMainWindow::OnOpenCitraFolder);
-    connect_menu(ui->action_FAQ, []() {
-        QDesktopServices::openUrl(QUrl(QStringLiteral("https://citra-emu.org/wiki/faq/")));
-    });
     connect_menu(ui->action_About, &GMainWindow::OnMenuAboutCitra);
 
 #if ENABLE_QT_UPDATER

--- a/src/lemonade_qt/main.cpp
+++ b/src/lemonade_qt/main.cpp
@@ -23,7 +23,9 @@
 #define _WIN32_WINNT 0x0A00
 #include <windows.h>
 #include <dwmapi.h>
+#ifdef _MSC_VER
 #pragma comment(lib, "dwmapi.lib")
+#endif
 #endif
 #ifdef __unix__
 #include <QVariant>

--- a/src/lemonade_qt/main.ui
+++ b/src/lemonade_qt/main.ui
@@ -201,7 +201,6 @@
     <addaction name="separator"/>
     <addaction name="action_Report_Compatibility"/>
     <addaction name="separator"/>
-    <addaction name="action_FAQ"/>
     <addaction name="action_About"/>
    </widget>
    <addaction name="menu_File"/>

--- a/src/lemonade_qt/util/graphics_device_info.cpp
+++ b/src/lemonade_qt/util/graphics_device_info.cpp
@@ -22,7 +22,8 @@ QString GetOpenGLRenderer() {
     QOpenGLContext context;
     if (context.create()) {
         context.makeCurrent(&surface);
-        return QString::fromUtf8(context.functions()->glGetString(GL_RENDERER));
+        return QString::fromUtf8(
+            reinterpret_cast<const char*>(context.functions()->glGetString(GL_RENDERER)));
     } else {
         return QStringLiteral("");
     }

--- a/src/video_core/host_shaders/opengl_present_anaglyph.frag
+++ b/src/video_core/host_shaders/opengl_present_anaglyph.frag
@@ -4,17 +4,22 @@
 
 //? #version 430 core
 
-// Anaglyph Red-Cyan shader based on Dubois algorithm
-// Constants taken from the paper:
-// "Conversion of a Stereo Pair to Anaglyph with
-// the Least-Squares Projection Method"
-// Eric Dubois, March 2009
-const mat3 l = mat3( 0.437, 0.449, 0.164,
-              -0.062,-0.062,-0.024,
-              -0.048,-0.050,-0.017);
-const mat3 r = mat3(-0.011,-0.032,-0.007,
-               0.377, 0.761, 0.009,
-              -0.026,-0.093, 1.234);
+// Rendepth: Red/Cyan Anaglyph Filter Optimized for Stereoscopic 3D on LCD Monitors by Andres Hernandez.
+// Based on the paper "Producing Anaglyphs from Synthetic Images" by William Sanders, David F. McAllister.
+// Using concepts from "Methods for computing color anaglyphs" by David F. McAllister, Ya Zhou, Sophia Sullivan.
+// Original research from "Conversion of a Stereo Pair to Anaglyph with the Least-Squares Projection Method" by Eric Dubois
+
+const mat3 l = mat3(
+    vec3(0.4561, 0.500484, 0.176381),
+    vec3(-0.400822, -0.0378246, -0.0157589),
+    vec3(-0.0152161, -0.0205971, -0.00546856));
+
+const mat3 r = mat3(
+    vec3(-0.0434706, -0.0879388, -0.00155529),
+    vec3(0.378476, 0.73364, -0.0184503),
+    vec3(-0.0721527, -0.112961, 1.2264));
+
+const vec3 g = vec3(1.6, 0.8, 1.0);
 
 layout(location = 0) in vec2 frag_tex_coord;
 layout(location = 0) out vec4 color;
@@ -25,8 +30,17 @@ layout(binding = 1) uniform sampler2D color_texture_r;
 uniform vec4 resolution;
 uniform int layer;
 
+vec3 correct_color(vec3 col) {
+    vec3 result;
+    result.r = pow(col.r, 1.0 / g.r);
+    result.g = pow(col.g, 1.0 / g.g);
+    result.b = pow(col.b, 1.0 / g.b);
+    return result;
+}
 void main() {
     vec4 color_tex_l = texture(color_texture, frag_tex_coord);
     vec4 color_tex_r = texture(color_texture_r, frag_tex_coord);
-    color = vec4(color_tex_l.rgb*l+color_tex_r.rgb*r, color_tex_l.a);
+    vec3 color_anaglyph = clamp(color_tex_l.rgb * l, vec3(0.0), vec3(1.0)) + clamp(color_tex_r.rgb * r, vec3(0.0), vec3(1.0));
+    vec3 color_corrected = correct_color(color_anaglyph);
+    color = vec4(color_corrected, color_tex_l.a);
 }


### PR DESCRIPTION
This mostly fixes an issue where if you selected either an anaglyph or interlaced stereo 3D mode, the setting would save, but would not be re-enabled when launching a new game (specific to Vulkan, OpenGL was working as intended). This was not related to my code, it appears to be a long standing bug no one noticed. I also removed the remaining mentions of the old filter, however this did not seem to be related to the bug.